### PR TITLE
Check color and alpha keys to determine default gradient.

### DIFF
--- a/Assets/SVG Importer/Plugins/Core/Fills/CCGradient.cs
+++ b/Assets/SVG Importer/Plugins/Core/Fills/CCGradient.cs
@@ -47,7 +47,7 @@ namespace SVGImporter.Rendering
         public const string DEFAULT_GRADIENT_HASH = "GC999FFFFFFC000FFFFFFA999999A000999";
     	public CCGradientColorKey[] colorKeys;
     	public CCGradientAlphaKey[] alphaKeys;
-    	
+
     	public string hash {
     		get {
                 string hash = "G";

--- a/Assets/SVG Importer/Plugins/Core/SVGAsset.cs
+++ b/Assets/SVG Importer/Plugins/Core/SVGAsset.cs
@@ -1080,7 +1080,7 @@ namespace SVGImporter
                 if(_sharedGradients == null || _sharedGradients.Length == 0) return false;
                 if(_sharedGradients.Length == 1)
                 {
-                    if(_sharedGradients[0].hash == CCGradient.DEFAULT_GRADIENT_HASH) return false;
+                    if(SVGAtlasData.isDefaultGradient(_sharedGradients[0])) return false;
                 }
                 return true;
             }

--- a/Assets/SVG Importer/Plugins/Core/SVGAtlas.cs
+++ b/Assets/SVG Importer/Plugins/Core/SVGAtlas.cs
@@ -13,6 +13,7 @@ namespace SVGImporter
     {
         public CCGradient[] gradients;
         public Dictionary<string, CCGradient> gradientCache;
+        private static readonly CCGradient DefaultGradient = GetDefaultGradient();
 
         public void Init(int length)
             {
@@ -57,6 +58,38 @@ namespace SVGImporter
                 new CCGradientAlphaKey(1f, 0f), new CCGradientAlphaKey(1f, 1f)
             };            
             return new CCGradient(colorKeys, alphaKeys);
+        }
+
+        public bool isDefaultGradient(CCGradient gradient)
+        {
+            if (gradient == null)
+            {
+                return false;
+            }
+            if (gradient.colorKeys == null || gradient.colorKeys.Length != DefaultGradient.colorKeys.Length ||
+                gradient.alphaKeys == null || gradient.alphaKeys.Length != DefaultGradient.alphaKeys.Length)
+            {
+                return false;
+            }
+            for (int i = 0; i < gradient.colorKeys.Length; i++)
+            {
+                if (gradient.colorKeys[i].color != DefaultGradient.colorKeys[i].color ||
+                    gradient.colorKeys[i].time != DefaultGradient.colorKeys[i].time)
+                {
+                    return false;
+
+                }
+            }
+            for (int i = 0; i < gradient.alphaKeys.Length; i++)
+            {
+                if (gradient.alphaKeys[i].color != DefaultGradient.alphaKeys[i].color ||
+                    gradient.alphaKeys[i].time != DefaultGradient.alphaKeys[i].time)
+                {
+                    return false;
+
+                }
+            }
+            return true;
         }
 
         public CCGradient AddGradient(CCGradient gradient)


### PR DESCRIPTION
During profiling we found that CCGradient.hash generates a lot of garbage, the default gradient check can be simplified to check the gradient array values.