### PR TITLE
Check color and alpha keys to determine default gradient.

### DIFF
--- a/Assets/SVG Importer/Plugins/Core/Fills/CCGradient.cs
+++ b/Assets/SVG Importer/Plugins/Core/Fills/CCGradient.cs
@@ -314,6 +314,45 @@ namespace SVGImporter.Rendering
             return output;
         }
 
+        private static bool CompareRGBA(Color32 a, Color32 b)
+        {
+	        return a.r == b.r && a.g == b.g && a.b == b.b && a.a == b.a;
+        }
+
+        public bool GradientEquals(CCGradient gradient)
+        {
+	        if (gradient == null)
+	        {
+		        return false;
+	        }
+
+	        if (gradient.colorKeys == null || gradient.colorKeys.Length != colorKeys.Length ||
+	            gradient.alphaKeys == null || gradient.alphaKeys.Length != alphaKeys.Length)
+	        {
+		        return false;
+	        }
+
+	        for (int i = 0; i < gradient.colorKeys.Length; i++)
+	        {
+		        if (!CompareRGBA(gradient.colorKeys[i].color, colorKeys[i].color) ||
+		            gradient.colorKeys[i].time != this.colorKeys[i].time)
+		        {
+			        return false;
+		        }
+	        }
+
+	        for (int i = 0; i < gradient.alphaKeys.Length; i++)
+	        {
+		        if (gradient.alphaKeys[i].alpha != alphaKeys[i].alpha ||
+		            gradient.alphaKeys[i].time != alphaKeys[i].time)
+		        {
+			        return false;
+		        }
+	        }
+
+	        return true;
+        }
+
         // Note that Color32 and Color implictly convert to each other. You may pass a Color object to this method without first casting it.
         public static string ColorToHex (Color32 color)
         {

--- a/Assets/SVG Importer/Plugins/Core/SVGAsset.cs
+++ b/Assets/SVG Importer/Plugins/Core/SVGAsset.cs
@@ -1080,7 +1080,7 @@ namespace SVGImporter
                 if(_sharedGradients == null || _sharedGradients.Length == 0) return false;
                 if(_sharedGradients.Length == 1)
                 {
-                    if(_sharedGradients[0].hash == CCGradient.DEFAULT_GRADIENT_HASH) return false;
+                    if(SVGAtlasData.IsDefaultGradient(_sharedGradients[0])) return false;
                 }
                 return true;
             }

--- a/Assets/SVG Importer/Plugins/Core/SVGAtlas.cs
+++ b/Assets/SVG Importer/Plugins/Core/SVGAtlas.cs
@@ -13,6 +13,7 @@ namespace SVGImporter
     {
         public CCGradient[] gradients;
         public Dictionary<string, CCGradient> gradientCache;
+        private static readonly CCGradient DefaultGradient = GetDefaultGradient();
 
         public void Init(int length)
             {
@@ -57,6 +58,11 @@ namespace SVGImporter
                 new CCGradientAlphaKey(1f, 0f), new CCGradientAlphaKey(1f, 1f)
             };            
             return new CCGradient(colorKeys, alphaKeys);
+        }
+
+        public static bool IsDefaultGradient(CCGradient gradient)
+        {
+            return DefaultGradient.GradientEquals(gradient);
         }
 
         public CCGradient AddGradient(CCGradient gradient)


### PR DESCRIPTION
During profiling we found that CCGradient.hash generates a lot of garbage, the default gradient check can be simplified to check the gradient array values.