### PR TITLE
Replacing Legacy COLOR Shader Output with SV_Target & Replacing POSIT…

### DIFF
--- a/Assets/SVG Importer/Plugins/Shaders/Others/SolidColorTexOverlayAlphaBlended.shader
+++ b/Assets/SVG Importer/Plugins/Shaders/Others/SolidColorTexOverlayAlphaBlended.shader
@@ -49,7 +49,7 @@ Shader "SVG Importer/SolidColor/SolidColorTexOverlayAlphaBlended" {
 			    return o;
 			}
 			
-			half4 fragmentColor(vertex_output i) : COLOR
+			half4 fragmentColor(vertex_output i) : SV_Target
 			{
 				return i.color * tex2D(_MainTex, i.uv);
 			}

--- a/Assets/SVG Importer/Plugins/Shaders/Others/SolidColorTexOverlayAlphaBlendedAntialiased.shader
+++ b/Assets/SVG Importer/Plugins/Shaders/Others/SolidColorTexOverlayAlphaBlendedAntialiased.shader
@@ -52,7 +52,7 @@ Shader "SVG Importer/SolidColor/SolidColorTexOverlayAlphaBlendedAntialiased" {
 			    return o;
 			}
 			
-			half4 fragmentColor(vertex_output i) : COLOR
+			half4 fragmentColor(vertex_output i) : SV_Target
 			{
 				return i.color * tex2D(_MainTex, i.uv);
 			}

--- a/Assets/SVG Importer/Plugins/Shaders/SVGImporterGradientCG.cginc
+++ b/Assets/SVG Importer/Plugins/Shaders/SVGImporterGradientCG.cginc
@@ -25,7 +25,7 @@ struct vertex_input_normal
 
 struct vertex_output
 {
-    float4 vertex : POSITION;			    
+    float4 vertex : SV_POSITION;			    
     float4 uv0 : TEXCOORD0;
     float4 uv1 : TEXCOORD1;
     half4 color : COLOR;
@@ -73,14 +73,14 @@ vertex_output vertexGradientsAntialiased(vertex_input_normal v)
     return o;
 }
 
-float4 fragmentGradientsOpaque(vertex_output i) : COLOR
+float4 fragmentGradientsOpaque(vertex_output i) : SV_Target
 {
 	float gradient = dot(tex2D(_GradientShape, i.uv0), i.uv1) ;
 	float2 gradientColorUV = float2(i.uv0.z + gradient, i.uv0.w);
 	return float4(tex2D(_GradientColor, gradientColorUV).rgb * i.color.rgb, 1.0);
 }
 
-float4 fragmentGradientsAlphaBlended(vertex_output i) : COLOR
+float4 fragmentGradientsAlphaBlended(vertex_output i) : SV_Target
 {	
 	float gradient = dot(tex2D(_GradientShape, i.uv0), i.uv1) ;
 	float2 gradientColorUV = float2(i.uv0.z + gradient, i.uv0.w);

--- a/Assets/SVG Importer/Plugins/Shaders/SVGImporterSolidCG.cginc
+++ b/Assets/SVG Importer/Plugins/Shaders/SVGImporterSolidCG.cginc
@@ -37,7 +37,7 @@ vertex_output vertexColorAntialiased(vertex_input_normal v)
 	return o;
 }
 
-half4 fragmentColor(vertex_output i) : COLOR
+half4 fragmentColor(vertex_output i) : SV_Target
 {
 	return i.color;
 }

--- a/Assets/SVG Importer/Plugins/Shaders/SVGImporterUICG.cginc
+++ b/Assets/SVG Importer/Plugins/Shaders/SVGImporterUICG.cginc
@@ -21,7 +21,7 @@ struct vertex_input
 
 struct vertex_output
 {
-    float4 vertex : POSITION;			    
+    float4 vertex : SV_POSITION;			    
     float4 uv0 : TEXCOORD0;
     float4 uv1 : TEXCOORD1;
     float4 worldPosition : TEXCOORD2;
@@ -78,14 +78,14 @@ vertex_output vertexGradientsAntialiased(vertex_input v)
     return o;
 }
 
-half4 fragmentGradientsOpaque(vertex_output i) : COLOR
+half4 fragmentGradientsOpaque(vertex_output i) : SV_Target
 {
 	float gradient = dot(tex2D(_GradientShape, i.uv0), i.uv1) ;
 	float2 gradientColorUV = float2(i.uv0.z + gradient, i.uv0.w);
 	return float4((tex2D(_GradientColor, gradientColorUV).rgb + _TextureSampleAdd) * i.color.rgb, 1.0);
 }
 
-half4 fragmentGradientsAlphaBlended(vertex_output i) : COLOR
+half4 fragmentGradientsAlphaBlended(vertex_output i) : SV_Target
 {
 	float gradient = dot(tex2D(_GradientShape, i.uv0), i.uv1) ;
 	float2 gradientColorUV = float2(i.uv0.z + gradient, i.uv0.w);


### PR DESCRIPTION
…ION for vertex shader outputs to SV_POSITION

Replacing the Legacy D3D COLOR Semantic with the new SV_Target.

This has to be done to support proprietary Shader Languages which aren't supporting the old COLOR Semantic anymore.

Also, I placed in two instances of the POSITION Semantic in the Vertex Shader Output with the SV_POSITION Semantic.

From Direct X 10 onwards COLOR got replaced by SV_Target and POSITION got replaced by SV_POSITION

More information on this is here https://docs.microsoft.com/de-de/windows/win32/direct3dhlsl/dx-graphics-hlsl-semantics?redirectedfrom=MSDN