### PR TITLE
Changed Handles.DotCap to Handles.DotHandleCap

### DIFF
--- a/Assets/SVG Importer/Editor/Utils/SVGHandles.cs
+++ b/Assets/SVG Importer/Editor/Utils/SVGHandles.cs
@@ -267,7 +267,7 @@ namespace SVGImporter.Rendering
                     }
                 }
 
-                if (type == EventType.mouseDrag)
+                if (type == EventType.MouseDrag)
                 {
                     OnMouseDrag(vrTrs);
                     GUI.changed = true;
@@ -275,7 +275,7 @@ namespace SVGImporter.Rendering
                 }
 
                 // Cancel Operation
-                if (Event.current.type == EventType.keyDown && Event.current.keyCode == KeyCode.Escape)
+                if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Escape)
                 {
                     vrTrs.SetTransform(origVrTransform);
                     Reset();
@@ -285,7 +285,7 @@ namespace SVGImporter.Rendering
                 }
             }
 
-            if (type == EventType.repaint)
+            if (type == EventType.Repaint)
             {
                 RenderTransformationGizmos(vrTrs);
             }
@@ -595,7 +595,7 @@ namespace SVGImporter.Rendering
             Vector2 horizontal = (p2p0 - p1p3).normalized;
             Vector2 vertical = (p3p2 - p0p1).normalized;
 
-            Handles.DotCap(0, Vector2.Lerp(p2p0, p1p3, 0.5f), capRotation, transformCapSize);
+            Handles.DotHandleCap(0, Vector2.Lerp(p2p0, p1p3, 0.5f), capRotation, transformCapSize, EventType.Repaint);
             
             // p0
             SVGGizmos.ShowScaleCursor(p0, p3 - p0, transformCursorRadius);
@@ -604,7 +604,7 @@ namespace SVGImporter.Rendering
                 Handles.color = COLOR_HIGHLIGHTED;
             else
                 Handles.color = COLOR_SELECTED;
-            Handles.DotCap(0, p0, capRotation, transformCapSize);
+            Handles.DotHandleCap(0, p0, capRotation, transformCapSize, EventType.Repaint);
 
             // p1
             SVGGizmos.ShowScaleCursor(p1, p2 - p1, transformCursorRadius);
@@ -613,7 +613,7 @@ namespace SVGImporter.Rendering
                 Handles.color = COLOR_HIGHLIGHTED;
             else
                 Handles.color = COLOR_SELECTED;
-            Handles.DotCap(0, p1, capRotation, transformCapSize);
+            Handles.DotHandleCap(0, p1, capRotation, transformCapSize, EventType.Repaint);
             
             // p2
             SVGGizmos.ShowScaleCursor(p2, p1 - p2, transformCursorRadius);
@@ -622,7 +622,7 @@ namespace SVGImporter.Rendering
                 Handles.color = COLOR_HIGHLIGHTED;
             else
                 Handles.color = COLOR_SELECTED;
-            Handles.DotCap(0, p2, capRotation, transformCapSize);
+            Handles.DotHandleCap(0, p2, capRotation, transformCapSize, EventType.Repaint);
             
             // p3
             SVGGizmos.ShowScaleCursor(p3, p0 - p3, transformCursorRadius);
@@ -631,7 +631,7 @@ namespace SVGImporter.Rendering
                 Handles.color = COLOR_HIGHLIGHTED;
             else
                 Handles.color = COLOR_SELECTED;
-            Handles.DotCap(0, p3, capRotation, transformCapSize);
+            Handles.DotHandleCap(0, p3, capRotation, transformCapSize, EventType.Repaint);
             
             // p0-p1
             SVGGizmos.ShowScaleCursor(p0p1, p3p2 - p0p1, transformCursorRadius);
@@ -640,7 +640,7 @@ namespace SVGImporter.Rendering
                 Handles.color = COLOR_HIGHLIGHTED;
             else
                 Handles.color = COLOR_SELECTED;
-            Handles.DotCap(0, p0p1, capRotation, transformCapSize);
+            Handles.DotHandleCap(0, p0p1, capRotation, transformCapSize, EventType.Repaint);
             
             // p2-p0
             SVGGizmos.ShowScaleCursor(p2p0, p1p3 - p2p0, transformCursorRadius);
@@ -649,7 +649,7 @@ namespace SVGImporter.Rendering
                 Handles.color = COLOR_HIGHLIGHTED;
             else
                 Handles.color = COLOR_SELECTED;
-            Handles.DotCap(0, p2p0, capRotation, transformCapSize);
+            Handles.DotHandleCap(0, p2p0, capRotation, transformCapSize, EventType.Repaint);
             
             // p3-p2
             SVGGizmos.ShowScaleCursor(p3p2, p0p1 - p3p2, transformCursorRadius);
@@ -658,7 +658,7 @@ namespace SVGImporter.Rendering
                 Handles.color = COLOR_HIGHLIGHTED;
             else
                 Handles.color = COLOR_SELECTED;
-            Handles.DotCap(0, p3p2, capRotation, transformCapSize);
+            Handles.DotHandleCap(0, p3p2, capRotation, transformCapSize, EventType.Repaint);
             
             // p1-p3
             SVGGizmos.ShowScaleCursor(p1p3, p2p0 - p1p3, transformCursorRadius);
@@ -667,7 +667,7 @@ namespace SVGImporter.Rendering
                 Handles.color = COLOR_HIGHLIGHTED;
             else
                 Handles.color = COLOR_SELECTED;
-            Handles.DotCap(0, p1p3, capRotation, transformCapSize);
+            Handles.DotHandleCap(0, p1p3, capRotation, transformCapSize, EventType.Repaint);
             
             Handles.color = COLOR_SELECTED;
             SVGGizmos.Line(new Vector2[]{p0, p1, p3, p2, p0});


### PR DESCRIPTION
Fix: Update deprecated Handles.DotCap to Handles.DotHandleCap  

Updated the deprecated Handles.DotCap method to Handles.DotHandleCap to resolve compilation errors in newer Unity versions. This change maintains the same functionality while using the current recommended API.  

Changes made:  
- Replaced Handles.DotCap with Handles.DotHandleCap  
- Added required EventType.Repaint parameter  

This update resolves the "Handles.DotCap not found" error and ensures compatibility with current Unity versions.